### PR TITLE
Add multimodal support to Xenium loader function

### DIFF
--- a/src/monkeybread/util/_load_xenium.py
+++ b/src/monkeybread/util/_load_xenium.py
@@ -1,0 +1,104 @@
+import os
+from typing import Dict, Optional
+
+import anndata as ad
+import h5py
+import numpy as np
+import pandas as pd
+import scanpy as sc
+import tifffile
+import zarr
+
+# Extended deafult paths to incldue cell and nuceleus boundaries, and morphology images
+default_paths = {
+    "cache": "adata.h5ad",
+    "counts": "cells.csv.gz",
+    "coordinates": "cell_metadata.csv",
+    "transcripts": "transcripts.zarr.zip",
+    "cell_boundaries": "cell_boundaries.csv.gz",
+    "nucleus_boundaries": "nucleus_boundaries.csv.gz",
+    "morphology": "morphology.ome.tiff",
+}
+
+
+def load_xenium(
+    folder: Optional[str] = ".",
+    transcript_locations: Optional[bool] = None,
+    paths: Optional[Dict[str, str]] = None,
+) -> ad.AnnData:
+    """Loads data from Xenium, in accordance to the folder structure of the FFPE data release.
+
+    Parameters
+    ----------
+    folder : str 
+        A path from the current working directory to the folder containing the Xenium data.
+    transcript_locations: bool
+        Whether to include transcript location data in the final `AnnData` object.
+    paths : dict
+        Path to each of the files output by Xenium. Defaults are provided for common files.
+
+    Returns
+    -------
+    An annotated data matrix containing spatial data from Xenium.
+    """
+    # Add default paths to path dictionary, maintaining overrides
+    if paths is None:
+        paths = {}
+    for k, v in default_paths.items():
+        if k not in paths:
+            paths[k] = v
+
+    # Load the cell-by-gene count matrix using Scanpy
+    counts = sc.read(f"{folder}/{paths['counts']}", first_column_names=True, cache=True)
+    
+    # Load the cell coordinates metadata
+    coordinates = pd.read_csv(f"{folder}/{paths['coordinates']}")
+    coordinates = coordinates.rename({"Unnamed: 0": "cell_id"}, axis=1)
+    
+    # Slice the data matrix to match the available coordinates (if some cells are filtered)
+    data = counts[coordinates.cell_id]  # Slice data by coordinate index
+    
+    # Add spatial coordinates to the AnnData object
+    data.obsm["X_spatial"] = coordinates[["center_x", "center_y"]].to_numpy()
+    data.obs["width"] = coordinates["max_x"].to_numpy() - coordinates["min_x"].to_numpy()
+    data.obs["height"] = coordinates["max_y"].to_numpy() - coordinates["min_y"].to_numpy()
+    data.obs["fov"] = coordinates["fov"].to_numpy()
+    data.obs.index = [str(x) for x in  data.obs.index] # Ensure cell indices are strings
+
+    # Read transcripts locations (support for both CSV and Zarr)
+    if transcript_locations or (transcript_locations is None and os.path.exists(f"{folder}/{paths['transcripts']}")):
+        transcript_file = f"{folder}/{paths['transcripts']}"
+        if transcript_file.endswith("zarr.zip"):
+            transcript_data = zarr.open(transcript_file, mode='r')
+            # Here we assume zarr structure includes a 'gene', 'global_x', 'global_y' keys
+            transcript_df = pd.DataFrame({
+                'gene': transcript_data['gene'][:],
+                'global_x': transcript_data['global_x'][:],
+                'global_y': transcript_data['global_y'][:]
+            })
+        else:
+            transcript_df = pd.read_csv(transcript_file, index_col=0, usecols=["Unnamed: 0", "gene", "global_x", "global_y"])
+        data.uns["transcripts"] = transcript_df
+        
+    # Load cell boundaries
+    if os.path.exists(f"{folder}/{paths['cell_boundaries']}"):
+        cell_boundaries = pd.read_csv(f"{folder}/{paths['cell_boundaries']}")
+        data.obs["cell_boundaries"] = cell_boundaries
+    
+    # Load nucleus boundaries
+    if os.path.exists(f"{folder}/{paths['nucleus_boundaries']}"):
+        nucleus_boundaries = pd.read_csv(f"{folder}/{paths['nucleus_boundaries']}")
+        data.obs["nucleus_boundaries"] = nucleus_boundaries
+
+    # Load morphology image
+    if os.path.exists(f"{folder}/{paths['morphology']}"):
+        morphology = tifffile.imread(f"{folder}/{paths['morphology']}")
+        data.uns["morphology"] = morphology
+        
+    # Set raw data (preprocessed, but useful for further analyses)
+    data.raw = data
+
+    return data
+
+# Example usage:
+# adata = load_xenium(folder="path/to/xenium/data")


### PR DESCRIPTION
Adding functionality to Monkeybread for the Xenium Platform

Load Xenium In Situ data function (_load_xenium.py)

Key Modifications to the _load_merscope.py

1. Extended Default Paths: Added ```cell_boundaries```, ```nucleus_boundaries```, and ```morphology``` to the default paths dictionary. 

2. Transcript Loading: The function now supports reading ```transcripts``` from either a Zarr or CSV file. If the Zarr is detected, it opens the file with ```zarr``` and loads the relevant columns.

3. Cell and Nucleus Boundaries: The ``obs`` field of the ```AnnData``` object now contains both cell and nucleus boundary information if available. 

4. Morphology Image: The function loads the OME-TIFF image and stores it in the ```uns``` field of the ```AnnData``` object for downstream analysis and visualization. 

5. Consistency: The function still returns a fully compatible ```AnnData``` object, making it easy to use with downstream spatial transcriptomics analysis pipelines (e.g., ```Scanpy```, ```Squidpy```).

This modified function will be capable of handling all the multimodal data from the Xenium directory and integrate it into a unified AnnData object for spatial data analysis.
